### PR TITLE
feat: add users & tweets & replies seeders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -465,6 +465,11 @@
       "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
       "integrity": "sha1-xgkX8m3CNWYVZsaBBhwwPCsohCs="
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "connect-flash": "^0.1.1",

--- a/seeders/20220223070059-users-seed-file.js
+++ b/seeders/20220223070059-users-seed-file.js
@@ -1,0 +1,38 @@
+'use strict'
+const bcrypt = require('bcryptjs')
+const faker = require('faker')
+const USER_AMOUNT = 5
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Users', [{
+      account: 'root',
+      name: 'root',
+      email: 'root@example.com',
+      password: await bcrypt.hash('12345678', 10),
+      introduction: faker.lorem.text(),
+      avatar: 'https://i.imgur.com/zYddUs8.png',
+      cover: 'https://i.imgur.com/dfpDjBN.jpg',
+      role: 'admin',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    ...Array.from({ length: USER_AMOUNT }, (v, i) => ({
+      account: `user${i + 1}`,
+      name: `user${i + 1}`,
+      email: `user${i + 1}@example.com`,
+      password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10)),
+      introduction: faker.lorem.text(),
+      avatar: 'https://i.imgur.com/zYddUs8.png',
+      cover: 'https://i.imgur.com/dfpDjBN.jpg',
+      role: 'user',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }))
+    ], {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Users', null, {})
+  }
+}

--- a/seeders/20220223070059-users-seed-file.js
+++ b/seeders/20220223070059-users-seed-file.js
@@ -1,6 +1,9 @@
 'use strict'
 const bcrypt = require('bcryptjs')
 const faker = require('faker')
+const PASSWORD = '12345678'
+const AVATAR = 'https://i.imgur.com/zYddUs8.png'
+const COVER = 'https://i.imgur.com/dfpDjBN.jpg'
 const USER_AMOUNT = 5
 
 module.exports = {
@@ -9,10 +12,10 @@ module.exports = {
       account: 'root',
       name: 'root',
       email: 'root@example.com',
-      password: await bcrypt.hash('12345678', 10),
-      introduction: faker.lorem.text(),
-      avatar: 'https://i.imgur.com/zYddUs8.png',
-      cover: 'https://i.imgur.com/dfpDjBN.jpg',
+      password: await bcrypt.hash(PASSWORD, 10),
+      introduction: faker.lorem.text().slice(0, 150),
+      avatar: AVATAR,
+      cover: COVER,
       role: 'admin',
       createdAt: new Date(),
       updatedAt: new Date()
@@ -21,10 +24,10 @@ module.exports = {
       account: `user${i + 1}`,
       name: `user${i + 1}`,
       email: `user${i + 1}@example.com`,
-      password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10)),
-      introduction: faker.lorem.text(),
-      avatar: 'https://i.imgur.com/zYddUs8.png',
-      cover: 'https://i.imgur.com/dfpDjBN.jpg',
+      password: bcrypt.hashSync(PASSWORD, 10),
+      introduction: faker.lorem.text().slice(0, 150),
+      avatar: AVATAR,
+      cover: COVER,
       role: 'user',
       createdAt: new Date(),
       updatedAt: new Date()

--- a/seeders/20220223075539-tweets-seed-file.js
+++ b/seeders/20220223075539-tweets-seed-file.js
@@ -1,0 +1,27 @@
+'use strict'
+const faker = require('faker')
+const TWEET_AMOUNT = 10
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE role='user'",
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+
+    await queryInterface.bulkInsert('Tweets',
+      users.flatMap(user => {
+        return Array.from({ length: TWEET_AMOUNT }, () => ({
+          UserId: user.id,
+          description: faker.lorem.text(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }))
+      })
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Tweets', null, {})
+  }
+}

--- a/seeders/20220223075539-tweets-seed-file.js
+++ b/seeders/20220223075539-tweets-seed-file.js
@@ -13,7 +13,7 @@ module.exports = {
       users.flatMap(user => {
         return Array.from({ length: TWEET_AMOUNT }, () => ({
           UserId: user.id,
-          description: faker.lorem.text(),
+          description: faker.lorem.text().slice(0, 130),
           createdAt: new Date(),
           updatedAt: new Date()
         }))

--- a/seeders/20220223111331-replies-seed-file.js
+++ b/seeders/20220223111331-replies-seed-file.js
@@ -1,0 +1,31 @@
+'use strict'
+const faker = require('faker')
+const REPLY_AMOUNT = 3
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE role='user'",
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    const tweets = await queryInterface.sequelize.query(
+      'SELECT id FROM Tweets;',
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+
+    const tweetsArr = tweets.flatMap(tweet => {
+      return Array.from({ length: REPLY_AMOUNT }, () => ({
+        UserId: users[Math.floor(Math.random() * users.length)].id,
+        TweetId: tweet.id,
+        comment: faker.lorem.text(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }))
+    })
+    await queryInterface.bulkInsert('Replies', tweetsArr, {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Replies', null, {})
+  }
+}

--- a/seeders/20220223111331-replies-seed-file.js
+++ b/seeders/20220223111331-replies-seed-file.js
@@ -17,7 +17,7 @@ module.exports = {
       return Array.from({ length: REPLY_AMOUNT }, () => ({
         UserId: users[Math.floor(Math.random() * users.length)].id,
         TweetId: tweet.id,
-        comment: faker.lorem.text(),
+        comment: faker.lorem.text().slice(0, 130),
         createdAt: new Date(),
         updatedAt: new Date()
       }))


### PR DESCRIPTION
新增：
users seeder file
包含一位 admin 以及五位 user

tweets seeder file
每個 user( 不含 admin ) 都擁有10則 tweet，總共50則

replies seeder file
每則 tweet 都有 3 則回覆，同一人有可能在一則推文擁有兩則以上的回覆

#更新
移除magic number & 添加字數限制

使用者種子資料那邊，因為有迭帶的關係，導致用 async/await 會發生錯誤，一時間我找不出解決辦法，所以就用不同寫法了

再來是 hash
```
bcrypt.hash(password, saltRounds, function(err, hash) {
  // Store hash in database here
});
```
The above example gives the same result as the code below
```
bcrypt.genSalt(saltRounds, function(err, salt) {  
  bcrypt.hash(password, salt, function(err, hash) {
    // Store hash in database here
  });
});
```

這兩個寫法其實是一樣的喔