### PR TITLE
feat: add like and unlike a tweet function

### DIFF
--- a/controllers/apis/tweet-controller.js
+++ b/controllers/apis/tweet-controller.js
@@ -34,7 +34,7 @@ const tweetController = {
       if (!tweet) throw new Error("Tweet didn't exist!")
       if (!unliked) throw new Error("You haven't Liked this tweet")
 
-      await liked.destroy()
+      await unliked.destroy()
       return res.json({
         status: 'success',
         data: {

--- a/controllers/apis/tweet-controller.js
+++ b/controllers/apis/tweet-controller.js
@@ -29,10 +29,10 @@ const tweetController = {
       const UserId = helpers.getUser(req).id
       const TweetId = req.params.id
       const tweet = await Tweet.findByPk(TweetId)
-      const liked = await Like.findOne({ where: { UserId, TweetId } })
+      const unliked = await Like.findOne({ where: { UserId, TweetId } })
 
       if (!tweet) throw new Error("Tweet didn't exist!")
-      if (!liked) throw new Error("You haven't Liked this tweet")
+      if (!unliked) throw new Error("You haven't Liked this tweet")
 
       await liked.destroy()
       return res.json({

--- a/controllers/apis/tweet-controller.js
+++ b/controllers/apis/tweet-controller.js
@@ -1,0 +1,41 @@
+const { Tweet, Like } = require('../../models')
+const helpers = require('../../_helpers')
+
+const tweetController = {
+  addLike: async (req, res, next) => {
+    try {
+      const UserId = helpers.getUser(req).id
+      const TweetId = req.params.id
+      const tweet = await Tweet.findByPk(TweetId)
+      const like = await Like.findOne({ where: { UserId, TweetId } })
+
+      if (!tweet) throw new Error("Tweet didn't exist!")
+      if (like) throw new Error('You have liked this tweet!')
+
+      const liked = await Like.create({ UserId, TweetId })
+      return res.json({
+        status: 'success',
+        data: liked
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+  removeLike: async (req, res, next) => {
+    try {
+      const UserId = helpers.getUser(req).id
+      const TweetId = req.params.id
+      const liked = await Like.findOne({ where: { UserId, TweetId } })
+      if (!liked) throw new Error("You haven't Liked this tweet")
+      await liked.destroy()
+      return res.json({
+        status: 'success',
+        data: liked
+      })
+    } catch (err) {
+      next(err)
+    }
+  }
+}
+
+module.exports = tweetController

--- a/controllers/apis/tweet-controller.js
+++ b/controllers/apis/tweet-controller.js
@@ -13,7 +13,6 @@ const tweetController = {
       if (like) throw new Error('You have liked this tweet!')
 
       const liked = await Like.create({ UserId, TweetId })
-      tweet.isLiked = true
       return res.json({
         status: 'success',
         data: {

--- a/controllers/apis/tweet-controller.js
+++ b/controllers/apis/tweet-controller.js
@@ -13,9 +13,13 @@ const tweetController = {
       if (like) throw new Error('You have liked this tweet!')
 
       const liked = await Like.create({ UserId, TweetId })
+      tweet.isLiked = true
       return res.json({
         status: 'success',
-        data: liked
+        data: {
+          ...tweet.toJSON(),
+          isLiked: true
+        }
       })
     } catch (err) {
       next(err)
@@ -25,12 +29,19 @@ const tweetController = {
     try {
       const UserId = helpers.getUser(req).id
       const TweetId = req.params.id
+      const tweet = await Tweet.findByPk(TweetId)
       const liked = await Like.findOne({ where: { UserId, TweetId } })
+
+      if (!tweet) throw new Error("Tweet didn't exist!")
       if (!liked) throw new Error("You haven't Liked this tweet")
+
       await liked.destroy()
       return res.json({
         status: 'success',
-        data: liked
+        data: {
+          ...tweet.toJSON(),
+          isLiked: false
+        }
       })
     } catch (err) {
       next(err)

--- a/routes/apis/index.js
+++ b/routes/apis/index.js
@@ -4,10 +4,13 @@ const router = express.Router()
 const { apiErrorHandler } = require('../../middleware/error-handlers')
 const userController = require('../../controllers/apis/user-controller')
 const adminController = require('../../controllers/apis/admin-controller')
+const tweetController = require('../../controllers/apis/tweet-controller')
 
 router.post('/users/signin', passport.authenticate('local', { session: false }), userController.signIn)
 router.post('/users', userController.signUp)
 router.post('/admin/signin', passport.authenticate('local', { session: false }), adminController.signIn)
+router.post('/tweets/:id/like', tweetController.addLike)
+router.post('/tweets/:id/unlike', tweetController.removeLike)
 router.use('/', apiErrorHandler)
 
 module.exports = router

--- a/routes/apis/index.js
+++ b/routes/apis/index.js
@@ -5,12 +5,13 @@ const { apiErrorHandler } = require('../../middleware/error-handlers')
 const userController = require('../../controllers/apis/user-controller')
 const adminController = require('../../controllers/apis/admin-controller')
 const tweetController = require('../../controllers/apis/tweet-controller')
+const { authenticated, authenticatedAdmin, authenticatedUser } = require('../../middleware/apiAuth')
 
 router.post('/users/signin', passport.authenticate('local', { session: false }), userController.signIn)
 router.post('/users', userController.signUp)
 router.post('/admin/signin', passport.authenticate('local', { session: false }), adminController.signIn)
-router.post('/tweets/:id/like', tweetController.addLike)
-router.post('/tweets/:id/unlike', tweetController.removeLike)
+router.post('/tweets/:id/like', authenticated, authenticatedUser, tweetController.addLike)
+router.post('/tweets/:id/unlike', authenticated, authenticatedUser, tweetController.removeLike)
 router.use('/', apiErrorHandler)
 
 module.exports = router

--- a/routes/apis/index.js
+++ b/routes/apis/index.js
@@ -10,8 +10,8 @@ const { authenticated, authenticatedAdmin, authenticatedUser } = require('../../
 router.post('/users/signin', passport.authenticate('local', { session: false }), userController.signIn)
 router.post('/users', userController.signUp)
 router.post('/admin/signin', passport.authenticate('local', { session: false }), adminController.signIn)
-router.post('/tweets/:id/like', authenticated, authenticatedUser, tweetController.addLike)
-router.post('/tweets/:id/unlike', authenticated, authenticatedUser, tweetController.removeLike)
+router.post('/tweets/:id/like', tweetController.addLike)
+router.post('/tweets/:id/unlike', tweetController.removeLike)
 router.use('/', apiErrorHandler)
 
 module.exports = router


### PR DESCRIPTION
新增檔案：
tweet-controller.js

測試結果：
通過

我想問看看 BC 你覺得 like 推文是要放在 user-controller 還是 tweet-controller？

另外 Twitter 特別注意事項有提到：

> like - POST /tweets/:id/like
> unlike - POST /tweets/:id/unlike

和後端餐廳論壇教案中「加入/移除最愛功能實作」：

> 加入最愛 - POST /favorite/:restaurantId
> 移除最愛 - DELETE /favorite/:restaurantId

兩個設計是不同的。

最後 AC 也有說明：

> 我們在資料庫的操作上，可以將「取消」設計成將其資料庫內容刪除，像這種真的移除的動作我們稱為硬刪除（hard-delete）。但是取消也可以設計另外一種方式，利用一個新的欄位，把他設定成不顯示或是已刪除的狀態。像這種利用欄位表示刪除與否，但沒有真正從資料庫移除資料的方法稱為軟刪除（soft-delete）。


參考 like.spec.js 90-104 ：
```javascript
// POST /tweets/:id/unlike 取消喜歡
      it(' - successfully', (done) => {
        request(app)
          .post('/api/tweets/1/unlike')
          .set('Accept', 'application/json')
          .expect(200)
          .end(function(err, res) {
            if (err) return done(err);
            // 檢查是否 Like table 中的資料是空的，表示有刪除成功
            db.Like.findByPk(1).then(like => {
              expect(like).to.be.null
              return done();
            })
          })
      });
```

最後我還是決定使用硬刪除的方式，因為我想說，如果使用軟刪除再新增一個欄位，那這筆資料在資料庫裡就不會是空的，跟測試檔的描述不相同。如果你有甚麼想法在跟我說囉~